### PR TITLE
Non-linear bed slopes and collection updates.

### DIFF
--- a/oggm_edu/funcs.py
+++ b/oggm_edu/funcs.py
@@ -79,11 +79,54 @@ def edu_plotter(func):
         figsize=(12, 9),
         **kwargs,
     ):
-        with \
-                mpl.rc_context({"figure.figsize": figsize}), \
-                sns.plotting_context(sns_context), \
-                sns.axes_style(sns_axes_style)\
-                :
+        with mpl.rc_context({"figure.figsize": figsize}), sns.plotting_context(
+            sns_context
+        ), sns.axes_style(sns_axes_style):
             return func(*args, **kwargs)
 
     return context_wrapper
+
+
+def expression_parser(expression, numeric):
+    """Parse an uncomplete math expression e.g. '* 10' and apply it to supplied attribute.
+
+    Parameters
+    ----------
+    expression : string
+        Incomplete math expression in the form '* 5' or '- 10'. Can also be empty to leave
+        numeric un-affected.
+    numeric : int or float
+        Value to evaluate against expression.
+    Returns
+    -------
+    The full expression evaluated.
+    """
+
+    # is expression a string?
+    if not isinstance(expression, str):
+        raise TypeError("expression should be a string.")
+
+    elif not isinstance(numeric, (int, float)):
+        raise TypeError("numeric should be an integer or a float.")
+    # If expression is empty, we return the numeric.
+    elif expression == "":
+        return numeric
+
+    else:
+        # Extract the operator
+        operator = expression[0]
+        if operator not in ["*", "/", "+", "-"]:
+            raise ValueError(
+                "First part of expression should be either one of *, /, +, -."
+            )
+        # Extract the factor
+        factor = float(expression[1:])
+        # Create a table of possible expressions. Then we just pick the correct one for return.
+        expression_dict = {
+            "*": numeric * factor,
+            "/": numeric / factor,
+            "+": numeric + factor,
+            "-": numeric - factor,
+        }
+
+        return expression_dict[operator]

--- a/oggm_edu/glacier_bed.py
+++ b/oggm_edu/glacier_bed.py
@@ -112,7 +112,11 @@ class GlacierBed:
             # If slopes is not a sequence, then make it one.
             if not isinstance(slopes, Sequence):
                 slopes = [slopes]
-            #  Do we have suquences of both slopes and breakpoints?
+
+            # Make sure that the provided slopes are reasonable.
+            if (np.asarray(slopes) < 1).any() or (np.asarray(slopes) > 80).any():
+                raise ValueError("Slopes should be above 0 and below 80 degrees.")
+            #  Do we have sequence of both slopes and breakpoints?
             if isinstance(slopes, Sequence) and isinstance(slope_sections, Sequence):
                 # Are they compatible?
                 # There should be one more section compared to slopes

--- a/oggm_edu/glacier_collection.py
+++ b/oggm_edu/glacier_collection.py
@@ -27,15 +27,15 @@ class GlacierCollection:
         ----------
         glacier_list : list of glaciers objects
             Defaults to none. Has the possibility to add glaciers on the go.
+            Glaciers need to have the same bed slope.
         """
 
         self._glaciers = []
 
         # Do we have a list of glaciers?
         if glacier_list:
-            # Check that all are Glaciers.
-            if all(isinstance(glacier, Glacier) for glacier in glacier_list):
-                self._glaciers = glacier_list
+            # Use the add method.
+            self.add(glacier_list)
 
     def __repr__(self):
         return f"Glacier collection with {len(self._glaciers)} glaciers."
@@ -70,10 +70,21 @@ class GlacierCollection:
         else:
             pass
 
-    def check_collection(self, glacier):
+    def _check_collection(self, glacier):
         """Utility method. Check if the glaciers obey the collection rules.
-        They need to have the same domains for this to make sense I think."""
-        # TODO
+        Make sure that a new glacier has the same bed as other glaciers in the collection.
+
+        glacier : Glacier
+            New glacier to check against the collection.
+        """
+
+        # Since this happens as soon as a glacier is added to a collection, we only have to check
+        # against the previous glacier
+        beds_ok = np.array_equal(self._glaciers[-1].bed.bed_h, glacier.bed.bed_h)
+
+        # If beds are not ok
+        if not beds_ok:
+            raise ValueError("Bed of new glacier does not match beds in collection.")
 
     @property
     def glaciers(self):
@@ -116,7 +127,7 @@ class GlacierCollection:
             self.change_attributes(attributes_to_change)
 
     def add(self, glacier):
-        """Add one or more glaciers to the collection.
+        """Add one or more glaciers to the collection. Glaciers have to have the same slope.
 
         Parameters
         ----------
@@ -132,24 +143,26 @@ class GlacierCollection:
                         "Glacier collection can only contain glacier objects."
                     )
                 # Is the glacier already in the collection?
-                if glacier in self._glaciers:
+                elif glacier in self._glaciers:
                     raise AttributeError("Glacier is already in collection")
-                # If the glacier is an instance of Glacier, we can add it to
-                # the collection.
-                else:
-                    self._glaciers.append(glacier)
+                # If there are already glaciers in the collection, check that the new one fit.
+                elif self._glaciers:
+                    self._check_collection(glacier)
+                # If no throws, add it.
+                self._glaciers.append(glacier)
         # If not iterable
         else:
             # Check that glacier is of the right type.
             if not isinstance(glacier, Glacier):
                 raise TypeError("Glacier collection can only contain glacier objects.")
             # Is the glacier already in the collection?
-            if glacier in self._glaciers:
+            elif glacier in self._glaciers:
                 raise AttributeError("Glacier is already in collection")
-            # If the glacier is an instance of Glacier, we can add it to
-            # the collection.
-            else:
-                self._glaciers.append(glacier)
+            # If there are already glaciers in the collection, check that the new one fit.
+            elif self._glaciers:
+                self._check_collection(glacier)
+            # If no throws, add it.
+            self._glaciers.append(glacier)
 
     def change_attributes(self, attributes_to_change):
         """Change the attribute(s) of the glaciers in the collection.

--- a/oggm_edu/tests/test_funcs.py
+++ b/oggm_edu/tests/test_funcs.py
@@ -1,6 +1,8 @@
 import oggm_edu
+from oggm_edu.funcs import expression_parser
 import matplotlib.pyplot as plt
 from numpy.testing import assert_equal
+import pytest
 
 
 def test_plot_glacier_graphics():
@@ -18,3 +20,19 @@ def test_edu_plotter_decorator():
 
     ax = plot_sth(figsize=(16, 16))
     assert_equal(ax.get_figure().get_size_inches(), [16.0, 16.0])
+
+
+def test_expression_parser():
+    """Test the expression parser."""
+    # Does it work like we think it does?
+    assert 20 == expression_parser("*10", 2)
+    assert 4 == expression_parser("+ 2", 2.0)
+    assert 4.5 == expression_parser("+ 2.5", 2.0)
+    assert 1 == expression_parser("/ 2", 2.0)
+    assert 5 == expression_parser("", 5.0)
+
+    # Should raise
+    with pytest.raises(Exception) as e_info:
+        expression_parser(" * 10", 2)
+    with pytest.raises(Exception) as e_info:
+        expression_parser(" * 10", "elk")

--- a/oggm_edu/tests/test_glacier_bed.py
+++ b/oggm_edu/tests/test_glacier_bed.py
@@ -114,3 +114,15 @@ def test_non_linear_bed_constructor():
     # Bed top and bottom should always equal the first and last value in the bed_h.
     assert bed.bed_h[0] == bed.top
     assert bed.bed_h[-1] == bed.bottom
+
+    # Make sure we cant provide strange slop angles.
+    with pytest.raises(Exception) as e_info:
+        bed = GlacierBed(top=3600, bottom=3000, width=300, slopes=[90])
+
+    with pytest.raises(Exception) as e_info:
+        _ = GlacierBed(
+            altitudes=[2500, 2000, 1500],
+            widths=[500, 500, 250],
+            slopes=[25, -15],
+            slope_sections=[2500, 2200, 1400],
+        )

--- a/oggm_edu/tests/test_glacier_bed.py
+++ b/oggm_edu/tests/test_glacier_bed.py
@@ -1,5 +1,6 @@
 from oggm_edu import GlacierBed
 from numpy.testing import assert_equal
+import numpy as np
 import pytest
 
 
@@ -48,3 +49,68 @@ def test_constructor_attribute_assignment():
     assert_equal(bed.bed_h, [2500, 2250, 2000, 1750, 1500])
     # What should the widhts be? Linearly interpolated.
     assert_equal(bed.widths * bed.map_dx, [500, 500, 500, 375, 250])
+
+
+def test_non_linear_bed_constructor():
+    """Testing init of non-linear bed profiles."""
+    # Should throw when we don't have enough breakpoints.
+    with pytest.raises(Exception) as e_info:
+        _ = GlacierBed(
+            altitudes=[2500, 2000, 1500],
+            widths=[500, 500, 250],
+            slopes=[25, 15],
+            slope_sections=[2500, 2200],
+        )
+
+    # Should throw since bottom and last slope breakpoint don't match.
+    with pytest.raises(Exception) as e_info:
+        _ = GlacierBed(
+            altitudes=[2500, 2000, 1500],
+            widths=[500, 500, 250],
+            slopes=[25, 15],
+            slope_sections=[2500, 2200, 1400],
+        )
+
+    # 45 degrees beds are easy. Just linspace.
+    bed = GlacierBed(top=3600, bottom=3000, width=300, slopes=[45])
+
+    # Easy correct bed.
+    bed_h_corr = np.linspace(3600, 3000, 6)
+    # They should correspond.
+    assert_equal(bed_h_corr, bed.bed_h)
+
+    # This test should maybe work, but I'm also not sure if it is possible to get to work.
+    # Would require the distance_along_glacier to be variable.
+    # Basically the section that is supposed to be 45 degrees is just close to 45 degrees.
+    # This is because the interpolation over the distance_along_glacier does not take the
+    # exact step size needed for 45 degrees.
+    # bed = GlacierBed(
+    #     top=3600,
+    #     bottom=2000,
+    #     width=300,
+    #     slopes=[45, 10],
+    #     slope_breakpoints=[3600, 3000, 2000],
+    # )
+
+    # assert_equal(bed_h_corr, bed.bed_h[:6])
+
+    # # Easy correct bed.
+    # bed_h_corr = np.linspace(3600, 3000, 6)
+    # # They should correspond.
+    # assert_equal(bed_h_corr, bed.bed_h)
+
+    bed = GlacierBed(top=3600, bottom=3000, width=300, slopes=[44])
+    # Bed top and bottom should always equal the first and last value in the bed_h.
+    assert bed.bed_h[0] == bed.top
+    assert bed.bed_h[-1] == bed.bottom
+
+    # A more complex bed.
+    bed = GlacierBed(
+        altitudes=[2500, 2000, 1500],
+        widths=[500, 500, 250],
+        slopes=[25, 15],
+        slope_sections=[2500, 2200, 1500],
+    )
+    # Bed top and bottom should always equal the first and last value in the bed_h.
+    assert bed.bed_h[0] == bed.top
+    assert bed.bed_h[-1] == bed.bottom

--- a/oggm_edu/tests/test_glacier_collection.py
+++ b/oggm_edu/tests/test_glacier_collection.py
@@ -5,6 +5,8 @@ mb = MassBalance(ela=3000, gradient=8)
 bed = GlacierBed(top=3700, bottom=1500, width=600)
 glacier1 = Glacier(bed=bed, mass_balance=mb)
 glacier2 = Glacier(bed=bed, mass_balance=mb)
+bed_new = GlacierBed(top=3700, bottom=2500, width=300, slopes=45)
+glacier3 = Glacier(bed=bed_new, mass_balance=mb)
 
 # We need a global collection for testing the plots, for some efficiency.
 collection = GlacierCollection()
@@ -21,6 +23,19 @@ def test_constructor():
     # Should have length 2.
     assert len(collection.glaciers) == 2
 
+    # This should add the first two glaciers in the list.
+    with pytest.raises(Exception) as e_info:
+        collection = GlacierCollection([glacier1, glacier2, glacier3])
+    assert len(collection.glaciers) == 2
+
+
+def test_check_collection():
+    """We can't add any glacier to a collection. Beds have to match."""
+    collection = GlacierCollection([glacier1, glacier2])
+
+    with pytest.raises(Exception) as e_info:
+        collection._check_collection(glacier3)
+
 
 def test_add():
     collection = GlacierCollection([glacier1, glacier2])
@@ -32,6 +47,13 @@ def test_add():
     # But not possible to add the same glacier again.
     with pytest.raises(Exception) as e_info:
         collection.add(glacier1)
+
+    # Try adding a glacier with different bed.
+    # Should throw
+    with pytest.raises(Exception) as e_info:
+        collection.add(glacier3)
+    # Number of glaciers should remain the same.
+    assert len(collection.glaciers) == 3
 
 
 def test_fill():

--- a/oggm_edu/tests/test_glacier_collection.py
+++ b/oggm_edu/tests/test_glacier_collection.py
@@ -81,6 +81,23 @@ def test_change_attributes():
     assert collection.glaciers[0].mass_balance.gradient == 10
     assert collection.glaciers[1].mass_balance.gradient == 15
 
+    # Testing the expression assignment mechanism
+    collection = GlacierCollection()
+    collection.fill(glacier1, n=5)
+    # Change another attribute.
+    collection.change_attributes(
+        attributes_to_change={"basal_sliding": [10, 10, 10, 10, 10]}
+    )
+    collection.change_attributes(
+        attributes_to_change={"basal_sliding": ["* 5", "/ 5", "+ 5", "- 5", ""]}
+    )
+    # Did it work?
+    assert collection.glaciers[0].basal_sliding == 50
+    assert collection.glaciers[1].basal_sliding == 2
+    assert collection.glaciers[2].basal_sliding == 15
+    assert collection.glaciers[3].basal_sliding == 5
+    assert collection.glaciers[4].basal_sliding == 10
+
 
 def test_progress_to_year():
     """Test progressing the collection to a specified year"""


### PR DESCRIPTION
This pr introduce new functionality in two areas

- It is now possible to pass partial expressions (e.g. `"* 10"`) when batch changing attributes of glaciers in a collection. This will then evaluate the expression against the previous value of the attribute in question. Include tests.
- It is now possible to assign a slope, or a sequence of slopes,  when creating a `GlacierBed`. This is done with two new kwargs in the constructor: `slopes` and `slope_sections`. How they function is explained in signature. This also required some changes to collection - it is not possible to add glaciers with different slopes to the collection. This is done to keep plots working. Includes some simple tests. Closes #136.